### PR TITLE
Properly protect select_expander

### DIFF
--- a/lib/Weasel/FindExpanders/HTML.pm
+++ b/lib/Weasel/FindExpanders/HTML.pm
@@ -217,7 +217,7 @@ sub select_expander {
     my @clauses;
     for my $clause (qw/ id name /) {
         push @clauses, "\@$clause='$args{$clause}'"
-            if defined $clause;
+            if defined $args{$clause};
     }
     my $clause = join ' and ', @clauses;
     return ".//select[$clause]";


### PR DESCRIPTION
Remove `Use of uninitialized value in concatenation` warning by validating against arguments instead of loop variable.