### PR TITLE
Add get_property for W3C / Selenium3 compatibility

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+** 0.14 / 2018-03-21
+   - Add get_property for W3C / Selenium3 compatibility
+
 ** 0.12 / 2016-10-03
    - Make 'get_page_source' write into a file
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name     = Weasel
 abstract = PHP's Mink inspired multi-protocol web-testing library for Perl
-version  = 0.12
+version  = 0.14
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Pherkin/Extension/Weasel.pm

--- a/lib/Weasel/DriverRole.pm
+++ b/lib/Weasel/DriverRole.pm
@@ -5,7 +5,7 @@ Weasel::DriverRole - API definition for driver wrappers
 
 =head1 VERSION
 
-0.02
+0.03
 
 =head1 SYNOPSIS
 
@@ -33,7 +33,7 @@ use warnings;
 use Carp;
 use Moose::Role;
 
-our $VERSION = '0.02';
+our $VERSION = '0.03';
 
 =head1 ATTRIBUTES
 
@@ -230,6 +230,17 @@ of the element indicated by C<$element_id>.
 
 sub get_attribute {
     croak "Abstract interface method 'get_attribute' called";
+}
+
+=item get_property($element_id, $property_name)
+
+Returns the value of the property named by C<$property_name>
+of the element indicated by C<$element_id>.
+
+=cut
+
+sub get_property {
+    croak "Abstract interface method 'get_property' called";
 }
 
 =item get_page_source($fh)

--- a/lib/Weasel/Element.pm
+++ b/lib/Weasel/Element.pm
@@ -5,7 +5,7 @@ Weasel::Element - The base HTML/Widget element class
 
 =head1 VERSION
 
-0.01
+0.02
 
 =head1 SYNOPSIS
 
@@ -112,6 +112,24 @@ sub get_attribute {
     my ($self, $attribute) = @_;
 
     return $self->session->get_attribute($self, $attribute);
+}
+
+=item get_property($property)
+
+Returns the value of the element's property named in C<$property> or
+C<undef> if none exists.
+
+Note: Some browsers apply default values to propertys which are not
+  part of the original page.  As such, there's no direct relation between
+  the existence of propertys in the original page and this function
+  returning C<undef>.
+
+=cut
+
+sub get_property {
+    my ($self, $property) = @_;
+
+    return $self->session->get_property($self, $property);
 }
 
 =item get_text()

--- a/lib/Weasel/Session.pm
+++ b/lib/Weasel/Session.pm
@@ -5,7 +5,7 @@ Weasel::Session - Connection to an encapsulated test driver
 
 =head1 VERSION
 
-0.03
+0.04
 
 =head1 SYNOPSIS
 
@@ -42,7 +42,7 @@ use Module::Runtime qw/ use_module /;;
 use Weasel::FindExpanders qw/ expand_finder_pattern /;
 use Weasel::WidgetHandlers qw| best_match_handler_class |;
 
-our $VERSION = '0.03';
+our $VERSION = '0.04';
 
 
 =head1 ATTRIBUTES
@@ -289,6 +289,22 @@ sub get_attribute {
         sub {
             return $self->driver->get_attribute($element->_id, $attribute);
         }, 'get_attribute', "element attribute '$attribute'");
+}
+
+=item get_property($element, $property)
+
+Returns the value of the property named by C<$property> of the element
+identified by C<$element>, or C<undef> if the property isn't defined.
+
+=cut
+
+sub get_property {
+    my ($self, $element, $property) = @_;
+
+    return $self->_logged(
+        sub {
+            return $self->driver->get_property($element->_id, $property);
+        }, 'get_property', "element property '$property'");
 }
 
 =item get_text($element)


### PR DESCRIPTION
Add W3C functionality, get_attribute and get_property are now 2 functions.
This departs from JSON which would first try to return the value of a property with the given name. If a property with that name doesn’t exist, it returns the value of the attribute with the same name.