### PR TITLE
Rely on driver to get checkbox & radio selected instead of attribute

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+** 0.27 / 2020-12-12
+   - Rely on driver to get input checkbox & radio selected state
+
 ** 0.26 / 2019-08-14
    - Add 'on_timeout' callback to 'wait_for' driver API
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name     = Weasel
 abstract = PHP's Mink inspired multi-protocol web-testing library for Perl
 ;'
-version  = 0.26
+version  = 0.27
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Weasel.pm

--- a/lib/Weasel.pm
+++ b/lib/Weasel.pm
@@ -5,7 +5,7 @@ Weasel - Perl's php/Mink-inspired abstracted web-driver framework
 
 =head1 VERSION
 
-0.26
+0.27
 
 =head1 SYNOPSIS
 
@@ -116,7 +116,7 @@ use warnings;
 use Moose;
 use namespace::autoclean;
 
-our $VERSION = '0.26';
+our $VERSION = '0.27';
 
 # From https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions
 my %key_codes = (

--- a/lib/Weasel/Widgets/HTML/Selectable.pm
+++ b/lib/Weasel/Widgets/HTML/Selectable.pm
@@ -64,7 +64,7 @@ sub selected {
     my ($self, $new_value) = @_;
 
     if (defined $new_value) {
-        my $selected = $self->session->get_attribute($self, 'selected');
+        my $selected = $self->session->get_selected($self);
         if (! $new_value && $selected) {
             $self->click; # unselect
         }
@@ -72,7 +72,7 @@ sub selected {
             $self->click; # select
         }
     }
-    return $self->session->get_attribute($self, 'selected');
+    return $self->session->get_selected($self);
 }
 
 =item value([$new_value])


### PR DESCRIPTION
Rely on the driver to get input checkbox & radio selected state instead of using an attribute.