### PR TITLE
Use javascript workaround to fix Firefox problem with TEXTAREA value

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-** 0.28 / 2021-03-29
+** 0.28 / 2021-06-09
    - Use a javascript workaround to get textarea value to fix Firefox problem
 
 ** 0.27 / 2020-12-19

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+** 0.28 / 2021-03-29
+   - Use a javascript workaround to get textarea value to fix Firefox problem
+
 ** 0.27 / 2020-12-19
    - Rely on driver to get input checkbox & radio selected state
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name     = Weasel
 abstract = PHP's Mink inspired multi-protocol web-testing library for Perl
 ;'
-version  = 0.27
+version  = 0.28
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Weasel.pm

--- a/lib/Weasel/Widgets/HTML/Input.pm
+++ b/lib/Weasel/Widgets/HTML/Input.pm
@@ -5,7 +5,7 @@ Weasel::Widgets::HTML::Input - Parent of the INPUT, OPTION, TEXTAREA and BUTTON 
 
 =head1 VERSION
 
-0.02
+0.28
 
 =head1 SYNOPSIS
 
@@ -81,7 +81,12 @@ sub value {
         $self->clear;
         $self->send_keys($value);
     }
-
+    if ( $self->tag_name eq 'textarea') {
+        return $self->session->driver->execute_script(qq{
+            var elem = arguments[0];
+            return elem.value;
+        },$self->_id);
+    }
     return $self->session->get_attribute($self, 'value');
 }
 
@@ -126,4 +131,3 @@ Licensed under the same terms as Perl.
 __PACKAGE__->meta->make_immutable;
 
 1;
-


### PR DESCRIPTION
This fix makes sure that TEXTAREA value is available.